### PR TITLE
Make JS coloring more similar to VS Code Night Owl

### DIFF
--- a/night-owl-theme.el
+++ b/night-owl-theme.el
@@ -302,7 +302,7 @@ Also affects 'linum-mode' background."
      ((t (:foreground ,night-owl-comments))))
 
    `(font-lock-constant-face
-     ((t (:foreground ,night-owl-violet))))
+     ((t (:foreground ,night-owl-orange))))
 
    `(font-lock-doc-face
      ((t (:foreground ,(if night-owl-doc-face-as-comment
@@ -339,7 +339,7 @@ Also affects 'linum-mode' background."
                       :italic nil))))
 
    `(font-lock-variable-name-face
-     ((t (:foreground ,night-owl-green))))
+     ((t (:foreground ,night-owl-blue))))
 
    `(font-lock-warning-face
      ((t (:foreground ,night-owl-orange
@@ -2364,7 +2364,7 @@ Also affects 'linum-mode' background."
      ((t (:foreground ,night-owl-green))))
 
    `(js2-function-call
-     ((t (:foreground ,night-owl-foreground))))
+     ((t (:foreground ,night-owl-blue))))
 
    `(js2-function-param
      ((t (:foreground ,night-owl-green))))
@@ -2391,7 +2391,10 @@ Also affects 'linum-mode' background."
      ((t (:underline t))))
 
    `(js2-object-property
-     ((t (:foreground ,night-owl-foreground))))
+     ((t (:foreground ,night-owl-magenta))))
+
+   `(js2-object-property-access
+     ((t (:foreground ,night-owl-cyan))))
 
    `(js2-private-function-call
      ((t (:foreground ,night-owl-violet))))
@@ -3388,16 +3391,16 @@ Also affects 'linum-mode' background."
      ((t (:foreground ,night-owl-blue))))
 
    `(rainbow-delimiters-depth-3-face
-     ((t (:foreground ,night-owl-orange))))
-
-   `(rainbow-delimiters-depth-4-face
      ((t (:foreground ,night-owl-yellow))))
 
-   `(rainbow-delimiters-depth-5-face
+   `(rainbow-delimiters-depth-4-face
      ((t (:foreground ,night-owl-green))))
 
-   `(rainbow-delimiters-depth-6-face
+   `(rainbow-delimiters-depth-5-face
      ((t (:foreground ,night-owl-magenta))))
+
+   `(rainbow-delimiters-depth-6-face
+     ((t (:foreground ,night-owl-orange))))
 
    `(rainbow-delimiters-depth-7-face
      ((t (:foreground ,night-owl-violet))))
@@ -3406,16 +3409,16 @@ Also affects 'linum-mode' background."
      ((t (:foreground ,night-owl-blue))))
 
    `(rainbow-delimiters-depth-9-face
-     ((t (:foreground ,night-owl-orange))))
-
-   `(rainbow-delimiters-depth-10-face
      ((t (:foreground ,night-owl-yellow))))
 
-   `(rainbow-delimiters-depth-11-face
+   `(rainbow-delimiters-depth-10-face
      ((t (:foreground ,night-owl-green))))
 
-   `(rainbow-delimiters-depth-12-face
+   `(rainbow-delimiters-depth-11-face
      ((t (:foreground ,night-owl-magenta))))
+
+   `(rainbow-delimiters-depth-12-face
+     ((t (:foreground ,night-owl-orange))))
 
    `(rainbow-delimiters-unmatched-face
      ((t (:foreground ,night-owl-foreground


### PR DESCRIPTION
I also modified the rainbow delim order to place orange later since it is the same color as constants which I found looked weird, but I suppose that's personal preference. (e.g. [1,2,3] would have the brackets the same color as the numbers)

Updated:
![image](https://user-images.githubusercontent.com/793847/63595140-38c16a00-c586-11e9-8666-70bbdd75ee28.png)

VS Code:
![image](https://user-images.githubusercontent.com/793847/63595232-6a3a3580-c586-11e9-9ff9-a830e88f2b8c.png)


Previous (sorry wrong bg in this screenshot, but the rest is right):
![image](https://user-images.githubusercontent.com/793847/63595181-4a0a7680-c586-11e9-98a1-27b7e6a6718d.png)
