### PR TITLE
Use original color for type-face + Use white for variable name

### DIFF
--- a/night-owl-theme.el
+++ b/night-owl-theme.el
@@ -218,6 +218,11 @@ Also affects 'linum-mode' background."
   "Adaptive colors - cursor"
   :type 'string
   :group 'night-owl)
+
+(defcustom night-owl-classname "#FFCB8B"
+  "Adaptive colors - class name"
+  :type 'string
+  :group 'night-owl)
 ;; }}}
 
 ;; Variables {{{
@@ -335,11 +340,11 @@ Also affects 'linum-mode' background."
      ((t (:foreground ,night-owl-string))))
 
    `(font-lock-type-face
-     ((t (:foreground ,night-owl-magenta
+     ((t (:foreground ,night-owl-classname
                       :italic nil))))
 
    `(font-lock-variable-name-face
-     ((t (:foreground ,night-owl-blue))))
+     ((t (:foreground ,night-owl-white))))
 
    `(font-lock-warning-face
      ((t (:foreground ,night-owl-orange


### PR DESCRIPTION
Hi, thank you for this nice theme.

This PR changes `font-lock-type-face` and `font-lock-variable-name`.
Before:
![image](https://user-images.githubusercontent.com/16046705/85267293-0b985d80-b4b0-11ea-9703-09a8f21e995b.png)

After:
![image](https://user-images.githubusercontent.com/16046705/85267217-ec013500-b4af-11ea-962a-ccf191d00a83.png)

VSCode:
![image](https://user-images.githubusercontent.com/16046705/85267341-1ce16a00-b4b0-11ea-8d9b-acb708f60ee6.png)

